### PR TITLE
implement watcher

### DIFF
--- a/watcher.ts
+++ b/watcher.ts
@@ -1,0 +1,63 @@
+import { decodeKeypress, Keypress } from "./mod.ts";
+
+class KeypressWatcher implements AsyncIterable<Keypress> {
+  // @ts-ignore
+  private closingPromiseResolve: (value: number) => void;
+  private closingPromise;
+
+  constructor(
+    private reader: Deno.Reader & Deno.Closer & { rid: number },
+    private bufferLength: number,
+  ) {
+    if (!Deno.isatty(reader.rid)) {
+      throw new Error("Keypress can be read only under TTY.");
+    }
+
+    this.closingPromise = new Promise((resolve) => {
+      this.closingPromiseResolve = resolve;
+    });
+  }
+
+  /** Stops watching the input. */
+  close(): void {
+    this.closingPromiseResolve(-1);
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Keypress> {
+    // @ts-ignore
+    const that = this;
+
+    return {
+      async next() {
+        const buffer = new Uint8Array(that.bufferLength);
+        // @ts-ignore
+        Deno.setRaw(that.reader.rid, true);
+        const length = <number> await Promise.race([
+          that.reader.read(buffer),
+          that.closingPromise,
+        ]);
+        // @ts-ignore
+        Deno.setRaw(that.reader.rid, false);
+
+        if (length === -1) {
+          that.reader.close();
+          return Promise.resolve({ value: undefined, done: true });
+        }
+
+        const [event] = decodeKeypress(buffer.subarray(0, length));
+
+        return Promise.resolve({
+          value: event,
+          done: false,
+        });
+      },
+    };
+  }
+}
+
+export function watchKeypress(
+  reader: Deno.Reader & Deno.Closer & { rid: number } = Deno.stdin,
+  bufferLength = 1024,
+): KeypressWatcher {
+  return new KeypressWatcher(reader, bufferLength);
+}

--- a/watcher_test.ts
+++ b/watcher_test.ts
@@ -1,0 +1,12 @@
+import { watchKeypress } from "./watcher.ts";
+
+const watcher = watchKeypress();
+
+setTimeout(() => {
+  console.log("closing watcher");
+  watcher.close();
+}, 3000);
+
+for await (const keypress of watcher) {
+  console.log(keypress);
+}


### PR DESCRIPTION
#6 The first version of the keypress watcher.

"Close" method stops iterator and closes reader.